### PR TITLE
Add onClick handler to FButton

### DIFF
--- a/src/components/atoms/FButton/FButton.stories.tsx
+++ b/src/components/atoms/FButton/FButton.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 import FButton from './FButton';
 
@@ -8,6 +9,7 @@ const meta = {
   parameters: {
     layout: 'centered',
   },
+  args: { onClick: fn() },
   tags: ['autodocs'],
 } satisfies Meta<typeof FButton>;
 

--- a/src/components/atoms/FButton/FButton.tsx
+++ b/src/components/atoms/FButton/FButton.tsx
@@ -3,11 +3,16 @@ import { Button, ButtonProps, Typography, Box } from "@mui/material";
 interface FButtonProps {
   innerText?: string;
   options?: ButtonProps;
+  onClick?: () => void;
 }
 
 export default function FButton(props: FButtonProps) {
   return (
-    <Button {...props.options} style={{textTransform: 'none', padding: 0, borderRadius: 8, maxHeight: 48 }}>
+    <Button 
+    {...props.options} 
+    style={{textTransform: 'none', padding: 0, borderRadius: 8, maxHeight: 48 }}
+    onClick={props.onClick}
+    >
       { props.innerText &&  
         <Box padding={2}>
           <Typography variant="body1" fontWeight={600}>


### PR DESCRIPTION
Adding missing event handler.
![Screenshot 2024-10-30 at 22 06 14](https://github.com/user-attachments/assets/267f3799-0e49-4aa9-a9a2-ddbe4af5dbe1)
